### PR TITLE
Use shutil for moving temporary file

### DIFF
--- a/src/safe.py
+++ b/src/safe.py
@@ -1,6 +1,7 @@
 """ Implementation of pol safes.  See `Safe`. """
 
 import os
+import shutil
 import time
 import struct
 import logging
@@ -109,7 +110,7 @@ def open(path, readonly=False, progress=None, nworkers=None, use_threads=False,
                                  use_threads=use_threads)
                 with tempfile.NamedTemporaryFile(delete=False) as f:
                     safe.store_to_stream(f)
-                    os.rename(f.name, path)
+                    shutil.move(f.name, path)
     except lockfile.AlreadyLocked:
         raise SafeLocked
     finally:


### PR DESCRIPTION
os.rename caused an `OSError: [Errno 18] Cross-device link` on my
machine.